### PR TITLE
[MORPH-4112] Fix for provisions using multi-disk templates

### DIFF
--- a/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
@@ -1381,7 +1381,7 @@ class OlvmProvisionProvider extends AbstractProvisionProvider implements VmProvi
 			rtn = workload.workloadType.virtualImage
 		}
 		else if (containerConfig.template) {
-			rtn = morpheus.async.virtualImage.get(containerConfig.template.value).blockingGet()
+			rtn = morpheus.async.virtualImage.get(containerConfig.template).blockingGet()
 		}
 		return rtn
 	}
@@ -1982,21 +1982,38 @@ class OlvmProvisionProvider extends AbstractProvisionProvider implements VmProvi
 					throw new RuntimeException("Unable to update disk size: ${OlvmComputeUtility.extractErrorMessage(response.data)}")
 				}
 
-				// add data disks via cloud api, then save off disk ids
-				if (runConfig.dataDisks?.size() > 0) {
+			// Handle data disks — some may already exist on the VM (cloned from template via disk_attachments),
+			// others are truly extra disks that need to be created fresh via the API
+			if (runConfig.dataDisks?.size() > 0) {
+				def clonedTemplateDisks = vmDetails.data.disks.findAll { d -> !d.bootable }
+				def extraDataDisks = []
+
+				runConfig.dataDisks.eachWithIndex { StorageVolume vol, int i ->
+					if (i < clonedTemplateDisks.size()) {
+						// This data disk was already cloned from the template — just assign its external id
+						vol.externalId = clonedTemplateDisks[i].id
+						saveAndGetVolume(vol)
+					} else {
+						// This is an extra disk beyond the template — needs to be created via API
+						extraDataDisks << vol
+					}
+				}
+
+				if (extraDataDisks) {
 					def dataDiskResp = OlvmComputeUtility.addDisksToVm([
 						connection: runConfig.connection, vmId: server.externalId,
-						disks     : runConfig.dataDisks
+						disks     : extraDataDisks
 					])
 
-					for (StorageVolume vol in runConfig.dataDisks) {
+					for (StorageVolume vol in extraDataDisks) {
 						def cloudDisk = dataDiskResp.data.disks.find { it -> return it.name == vol.name }
 						vol.externalId = cloudDisk.externalId
 						saveAndGetVolume(vol)
 					}
 				}
+			}
 
-				// add primary network interface if one does not exist on
+
 				if (!vmDetails.data.nics) {
 					def addPrimaryInterface = OlvmComputeUtility.addNicsToVm(
 						[connection: runConfig.connection, nics: [runConfig.networkConfig.primaryInterface], vmId: server.externalId]

--- a/src/main/groovy/com/morpheus/olvm/util/OlvmComputeUtility.groovy
+++ b/src/main/groovy/com/morpheus/olvm/util/OlvmComputeUtility.groovy
@@ -756,11 +756,59 @@ class OlvmComputeUtility {
                 'GET'
             )
 
-            def templateDisk = response.data['disk_attachment'].first()
+            // Get ALL template disk attachments — not just the first — so every disk gets a storage domain mapping
+            def templateDiskAttachments = response.data['disk_attachment']
+            if (!(templateDiskAttachments instanceof List)) {
+                templateDiskAttachments = [templateDiskAttachments]
+            }
 
-            // merge network interfaces
-            def interfaces = [opts.networkConfig.primaryInterface]
-            interfaces.addAll(opts.networkConfig.extraInterfaces)
+            def bootableTemplateDisk = templateDiskAttachments.find { it.bootable?.toBoolean() } ?: templateDiskAttachments.first()
+            def nonBootableTemplateDisks = templateDiskAttachments.findAll { it.id != bootableTemplateDisk.id }
+
+            // Root (bootable) disk maps to rootVolume's datastore (user-selected)
+            def rootStorageDomainId = opts.rootVolume.datastore.externalId
+            log.debug("createServer: root disk id=${bootableTemplateDisk.id} -> storage domain ${rootStorageDomainId}")
+            def diskAttachmentList = []
+            diskAttachmentList << [disk:[
+                id: bootableTemplateDisk.id,
+                'provisioned_size': opts.rootVolume.maxStorage,
+                'storage_domains': ['storage_domain': [[id: rootStorageDomainId]]]
+            ]]
+
+            // Non-bootable template disks: prefer user-specified datastore from Morpheus StorageVolume,
+            // but fall back to the template disk's own storage domain fetched directly from oVirt.
+            // This avoids "Storage Domain doesn't exist" errors from stale/missing Morpheus datastore records.
+            nonBootableTemplateDisks.eachWithIndex { nonBootableDisk, i ->
+                // Bounds-safe access: opts.dataDisks may have fewer entries than template non-boot disks
+                def userDatastoreId = (opts.dataDisks?.size() > i) ? opts.dataDisks[i]?.datastore?.externalId : null
+
+                def targetDatastoreId
+                if (userDatastoreId) {
+                    targetDatastoreId = userDatastoreId
+                    log.debug("createServer: data disk[${i}] id=${nonBootableDisk.id} -> user-specified storage domain ${targetDatastoreId}")
+                } else {
+                    // Fetch this disk's storage domain directly from oVirt — authoritative source
+                    def diskHref = nonBootableDisk.disk?.href ?: "/ovirt-engine/api/disks/${nonBootableDisk.id}".toString()
+                    def diskDetail = client.callJsonApi(connection.apiUrl, diskHref, reqOptions, 'GET')
+                    def templateDiskStorageDomainId = diskDetail.data?.storage_domains?.storage_domain?.first()?.id
+                    targetDatastoreId = templateDiskStorageDomainId ?: rootStorageDomainId
+                    log.debug("createServer: data disk[${i}] id=${nonBootableDisk.id} -> template disk's storage domain ${targetDatastoreId} (fetched from oVirt)")
+                }
+
+                diskAttachmentList << [disk:[
+                    id: nonBootableDisk.id,
+                    'storage_domains': ['storage_domain': [[id: targetDatastoreId]]]
+                ]]
+            }
+
+            // merge network interfaces — guard against null primaryInterface and null extraInterfaces list
+            def interfaces = []
+            if (opts.networkConfig?.primaryInterface) {
+                interfaces << opts.networkConfig.primaryInterface
+            }
+            if (opts.networkConfig?.extraInterfaces) {
+                interfaces.addAll(opts.networkConfig.extraInterfaces)
+            }
 
             // send vm create to api
             def postBody = [
@@ -770,11 +818,7 @@ class OlvmComputeUtility {
                 memory:opts.maxMemory,
                 cpu:buildCpus(opts.workloadConfig),
                 nics:[nic:buildNetworkInterfaces(interfaces)],
-                'disk_attachments':[
-                    'disk_attachment':[
-                        [disk:[id:templateDisk.id, 'provisioned_size':opts.rootVolume.maxStorage, 'storage_domains':['storage_domain':[[id:opts.rootVolume.datastore.externalId]]]]]
-                    ]
-                ]
+                'disk_attachments':['disk_attachment': diskAttachmentList]
             ]
             def postHeaders = getAuthenticatedBaseHeaders(connection)
             def postReqOptions = new HttpApiClient.RequestOptions(headers:postHeaders, body:postBody, ignoreSSL:true)
@@ -1862,7 +1906,9 @@ class OlvmComputeUtility {
     static List<Map> buildNetworkInterfaces(List interfaces) {
         def nics = []
         for (iface in interfaces) {
-            nics << buildNetworkInterface(iface)
+            if (iface != null) {
+                nics << buildNetworkInterface(iface)
+            }
         }
         return nics
     }


### PR DESCRIPTION
Root Cause

Two issues in OlvmComputeUtility.createServer():

Fix pt1 — Only .first() template disk attachment was used when building the VM create payload, so the second disk's storage domain was never specified — causing oVirt to reject the request.

Fix pt2 — After fixing pt1, non-bootable disks fell back to opts.dataDisks[i].datastore.externalId from Morpheus's stored StorageVolume data. This UUID was stale/unrecognized by oVirt, producing "Storage Domain doesn't exist."

Fix Summary

Iterate all template disk attachments (not just first) when building disk_attachments in the VM create POST.

For non-bootable disks, use a 3-tier priority to resolve the storage domain:

  1. User-specified datastore from Morpheus StorageVolume.datastore.externalId

  2. Template disk's own storage domain — fetched live from oVirt GET /api/disks/{id}

  3. Root volume's storage domain as final fallback

Also fixed buildNetworkInterfaces() NPE when primaryInterface or extraInterfaces is null.

Fixed insertVm() to avoid calling addDisksToVm for disks already cloned from the template.