### PR TITLE
Add stateless VM, disk provisioning, clone type, and host placement o…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,76 @@
+# Copilot Instructions for morpheus-olvm-plugin
+
+## Build & Deploy
+
+**Prerequisites:** Switch to Java 17 before building (Groovy 3 is incompatible with Java 25+):
+```bash
+sdk use java 17.0.11-jbr
+```
+
+**Build the shadow JAR:**
+```bash
+./gradlew shadowJar
+```
+Output: `build/libs/*-all.jar`
+
+**Deploy to local Morpheus plugin core for testing:**
+```bash
+mv build/libs/*-all.jar ~/code/morpheus-plugin-core/plugins/
+```
+
+**Run tests:**
+```bash
+./gradlew test
+```
+Tests use Spock framework (Groovy). No test files currently exist.
+
+## Architecture
+
+This is a **Morpheus cloud plugin** for Oracle Linux Virtualization Manager (OLVM). It integrates with the [morpheus-plugin-api](https://developer.morpheusdata.com) and is loaded into a Morpheus appliance at `Administration → Integrations → Plugins`.
+
+### Provider Registration
+
+`OlvmCloudPlugin` (extends `Plugin`) is the entry point — its `initialize()` registers all providers:
+- `OlvmCloudProvider` — cloud lifecycle, validation, periodic refresh/sync
+- `OlvmProvisionProvider` — VM provisioning/deprovisioning, resize
+- `OlvmOptionSourceProvider` — dynamic dropdown options (datacenters, clusters, etc.)
+- `OlvmBackupProvider` → `OlvmSnapshotBackupProvider` — snapshot-based backup
+
+### Sync Pattern
+
+`OlvmCloudProvider.refresh()` drives periodic synchronization. It calls each sync class sequentially, passing a shared `connection` map:
+```
+DatacenterSync → ClusterSync → StorageDomainSync → NetworkSync → HostSync → TemplateSync → VirtualMachineSync
+```
+
+Each sync class in `sync/` follows the same pattern using `SyncTask<IdentityProjection, Map, DomainObject>`:
+1. Fetch existing Morpheus records via `listIdentityProjections()`
+2. Fetch live OLVM data via `OlvmComputeUtility`
+3. `SyncTask` reconciles: `.onDelete()`, `.onUpdate()`, `.onAdd()`
+
+### API Communication
+
+All OLVM REST API calls go through `OlvmComputeUtility` (static utility class):
+- **Authentication:** OAuth2 password grant against `/ovirt-engine/sso/oauth/token` → returns bearer token
+- **Connection map:** `{apiUrl, token}` — passed around instead of re-authenticating each call
+- **Client:** `HttpApiClient` (from morpheus-plugin-api) with `ignoreSSL: true`
+- **Headers:** `getAuthenticatedBaseHeaders(connection)` → `Authorization: Bearer <token>`
+- **Base path:** `/ovirt-engine/api/...`
+
+### Key Conventions
+
+- All API methods in `OlvmComputeUtility` are `static` and return `ServiceResponse`
+- `ServiceResponse.prepare()` initializes a response; set `rtn.success = true` and `rtn.data = [...]` on success
+- Always call `client.shutdownClient()` in a `finally` block after `HttpApiClient` use
+- Credentials are loaded via `cloud.accountCredentialData` (Morpheus credential store); fall back to `cloud.serviceUsername`/`cloud.servicePassword`
+- Datacenter scoping: when `cloud.configMap.datacenter` is set (not `'all'`), filter by `clusterIds` derived from that datacenter
+- VM inventory sync only runs when `cloud.configMap.importExisting == 'on'`
+- `OlvmVersion.setMDC()` is called at the start of cloud refresh and plugin init for log correlation
+
+### Scribe Resources
+
+`src/main/resources/scribe/*.scribe` files declare Morpheus UI metadata (option types, layouts, compute types) using a Terraform-like HCL syntax. These are loaded by the Morpheus appliance at plugin install time — they are **not** Groovy code.
+
+### Plugin Manifest
+
+Plugin metadata (name, code `cloud.olvm`, min appliance version) is declared in `build.gradle` under `jar { manifest { attributes(...) } }`. The `Plugin-Class` must match `OlvmCloudPlugin`'s fully-qualified name.

--- a/src/main/groovy/com/morpheus/olvm/OlvmOptionSourceProvider.groovy
+++ b/src/main/groovy/com/morpheus/olvm/OlvmOptionSourceProvider.groovy
@@ -49,7 +49,55 @@ class OlvmOptionSourceProvider extends AbstractOptionSourceProvider {
 
     @Override
     List<String> getMethodNames() {
-        return new ArrayList<String>(['olvmDatacenters', 'olvmCloudDatacenters', 'olvmClusters', 'olvmTemplates', 'olvmCloudConfiguredDatacenter', 'olvmQcowImages'])
+        return new ArrayList<String>(['olvmDatacenters', 'olvmCloudDatacenters', 'olvmClusters', 'olvmTemplates', 'olvmCloudConfiguredDatacenter', 'olvmQcowImages', 'olvmHosts', 'olvmCloneTypes', 'olvmDiskProvisioningTypes', 'olvmHostAffinityTypes'])
+    }
+
+    def olvmCloneTypes(args) {
+        return [
+            [name: 'Linked Clone (thin, template-dependent)', value: 'linked', isDefault: true],
+            [name: 'Full Clone (independent copy)', value: 'full'],
+        ]
+    }
+
+    def olvmDiskProvisioningTypes(args) {
+        return [
+            [name: 'Thin (COW, sparse — supports snapshots)', value: 'thin', isDefault: true],
+            [name: 'Preallocated (COW, full allocation)', value: 'preallocated'],
+        ]
+    }
+
+    def olvmHostAffinityTypes(args) {
+        return [
+            [name: 'Migratable (soft preference, live migration allowed)', value: 'migratable', isDefault: true],
+            [name: 'User Migratable (only manual migration allowed)', value: 'user_migratable'],
+            [name: 'Pinned (hard pin, no migration)', value: 'pinned'],
+        ]
+    }
+
+    def olvmHosts(args) {
+        args = args instanceof Object[] ? args.getAt(0) : args
+        Cloud cloud = loadCloud(args)
+        def rtn = [[name: 'No preference (let OLVM decide)', value: '', isDefault: true]]
+
+        def filters = [
+            new DataFilter<String>('zone.id', cloud.id.toString()),
+            new DataFilter<String>('computeServerType.code', 'olvm-hypervisor')
+        ]
+        // When the user has already selected a cluster, filter hosts to only that cluster's members.
+        // clusterId is the Morpheus CloudPool.id, which is what olvmClusters returns as value — and
+        // what HostSync stores on ComputeServer.resourcePool.id.
+        if (args.clusterId) {
+            filters << new DataFilter<String>('resourcePool.id', args.clusterId.toString())
+        }
+
+        def result = morpheusContext.async.computeServer.search(
+            new DataQuery().withFilters(filters)
+        ).blockingGet()
+
+        for (host in result.items) {
+            rtn << [name: host.name, value: host.externalId]
+        }
+        return rtn
     }
 
     def olvmQcowImages(args) {

--- a/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
@@ -201,6 +201,79 @@ class OlvmProvisionProvider extends AbstractProvisionProvider implements VmProvi
 			inputType: OptionType.InputType.CHECKBOX,
 			helpBlock: 'Skipping Agent installation will result in a lack of logging and guest operating system statistics. Automation scripts may also be adversely affected.'
 		])
+		options << new OptionType([
+			name: 'cloneType',
+			code: 'olvm.plugin.provision.cloneType',
+			category: 'provisionType.olvm',
+			fieldName: 'cloneType',
+			fieldContext: 'config',
+			fieldLabel: 'Clone Type',
+			fieldGroup: 'Advanced Options',
+			inputType: OptionType.InputType.SELECT,
+			displayOrder: 120,
+			defaultValue: 'linked',
+			optionSource: 'olvmCloneTypes',
+			displayValueOnDetails: true,
+			helpBlock: 'Linked clone shares template storage and is faster to create, but the template cannot be deleted while linked VMs exist. Full clone is fully independent but uses more storage and takes longer to provision.'
+		])
+		options << new OptionType([
+			name: 'diskProvisioning',
+			code: 'olvm.plugin.provision.diskProvisioning',
+			category: 'provisionType.olvm',
+			fieldName: 'diskProvisioning',
+			fieldContext: 'config',
+			fieldLabel: 'Disk Provisioning',
+			fieldGroup: 'Advanced Options',
+			inputType: OptionType.InputType.SELECT,
+			displayOrder: 121,
+			defaultValue: 'thin',
+			optionSource: 'olvmDiskProvisioningTypes',
+			displayValueOnDetails: true,
+			helpBlock: 'Thin: only used blocks are allocated on disk; supports snapshots and stateless mode. Preallocated: all blocks are allocated at creation for more predictable storage performance.'
+		])
+		options << new OptionType([
+			name: 'stateless',
+			code: 'olvm.plugin.provision.stateless',
+			category: 'provisionType.olvm',
+			fieldName: 'stateless',
+			fieldContext: 'config',
+			fieldLabel: 'Stateless VM',
+			fieldGroup: 'Advanced Options',
+			inputType: OptionType.InputType.CHECKBOX,
+			displayOrder: 122,
+			displayValueOnDetails: true,
+			helpBlock: 'When enabled, VM disk state is automatically rolled back to its pre-start snapshot on every shutdown. Requires thin (COW) disk provisioning.'
+		])
+		options << new OptionType([
+			name: 'host',
+			code: 'olvm.plugin.provision.hostId',
+			category: 'provisionType.olvm',
+			fieldName: 'hostId',
+			fieldContext: 'config',
+			fieldLabel: 'Host',
+			fieldGroup: 'Advanced Options',
+			inputType: OptionType.InputType.SELECT,
+			displayOrder: 130,
+			required: false,
+			optionSource: 'olvmHosts',
+			displayValueOnDetails: true,
+			helpBlock: 'Optionally target a specific hypervisor host within the selected cluster. Leave blank to let OLVM choose.'
+		])
+		options << new OptionType([
+			name: 'hostAffinity',
+			code: 'olvm.plugin.provision.hostAffinity',
+			category: 'provisionType.olvm',
+			fieldName: 'hostAffinity',
+			fieldContext: 'config',
+			fieldLabel: 'Host Affinity',
+			fieldGroup: 'Advanced Options',
+			inputType: OptionType.InputType.SELECT,
+			displayOrder: 131,
+			defaultValue: 'migratable',
+			optionSource: 'olvmHostAffinityTypes',
+			displayValueOnDetails: true,
+			helpBlock: 'Controls migration behaviour when a host is selected. Migratable: prefer the host but allow live migration. User Migratable: only administrator-initiated migration allowed. Pinned: VM is locked to the selected host with no migration possible.'
+		])
 		return options
 	}
 
@@ -1538,6 +1611,22 @@ class OlvmProvisionProvider extends AbstractProvisionProvider implements VmProvi
 
 		def runConfig = [:] + opts + buildRunConfig(server, virtualImage, workloadRequest.networkConfiguration, connection, workloadConfig, opts)
 
+		def stateless = workloadConfig.stateless?.toString() == 'true' || workloadConfig.stateless == true
+		def diskProvisioning = workloadConfig.diskProvisioning ?: 'thin'
+		def cloneType = workloadConfig.cloneType ?: 'linked'
+
+		if (stateless && diskProvisioning == 'preallocated') {
+			log.warn("buildWorkloadRunConfig: stateless=true requires thin (COW) disk provisioning — overriding diskProvisioning to 'thin'")
+			diskProvisioning = 'thin'
+		}
+
+		def hostRef = null
+		def hostAffinity = workloadConfig.hostAffinity ?: 'migratable'
+		if (workloadConfig.hostId) {
+			// hostId is the OLVM externalId (UUID) returned directly by olvmHosts option source
+			hostRef = workloadConfig.hostId
+		}
+
 		runConfig += [
 			name              : server.name,
 			instanceId		  : workload.instance.id,
@@ -1555,7 +1644,12 @@ class OlvmProvisionProvider extends AbstractProvisionProvider implements VmProvi
 			userConfig        : workloadRequest.usersConfiguration,
 			cloudConfig	      : workloadRequest.cloudConfigUser,
 			cloudConfigNetwork: workloadRequest.cloudConfigNetwork,
-			networkConfig	  : workloadRequest.networkConfiguration
+			networkConfig	  : workloadRequest.networkConfiguration,
+			stateless         : stateless,
+			diskProvisioning  : diskProvisioning,
+			cloneType         : cloneType,
+			hostRef           : hostRef,
+			hostAffinity      : hostAffinity,
 		]
 
 		log.debug("buildWorkloadRunConfig - Cloud-init config length: ${runConfig.cloudConfig?.length()}")

--- a/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
@@ -256,6 +256,7 @@ class OlvmProvisionProvider extends AbstractProvisionProvider implements VmProvi
 			displayOrder: 130,
 			required: false,
 			optionSource: 'olvmHosts',
+			dependsOn: 'olvm.plugin.provision.cluster',
 			displayValueOnDetails: true,
 			helpBlock: 'Optionally target a specific hypervisor host within the selected cluster. Leave blank to let OLVM choose.'
 		])

--- a/src/main/groovy/com/morpheus/olvm/util/OlvmComputeUtility.groovy
+++ b/src/main/groovy/com/morpheus/olvm/util/OlvmComputeUtility.groovy
@@ -768,10 +768,13 @@ class OlvmComputeUtility {
             // Root (bootable) disk maps to rootVolume's datastore (user-selected)
             def rootStorageDomainId = opts.rootVolume.datastore.externalId
             log.debug("createServer: root disk id=${bootableTemplateDisk.id} -> storage domain ${rootStorageDomainId}")
+            def sparse = opts.diskProvisioning != 'preallocated'
             def diskAttachmentList = []
             diskAttachmentList << [disk:[
                 id: bootableTemplateDisk.id,
                 'provisioned_size': opts.rootVolume.maxStorage,
+                format: 'cow',
+                sparse: sparse,
                 'storage_domains': ['storage_domain': [[id: rootStorageDomainId]]]
             ]]
 
@@ -797,6 +800,8 @@ class OlvmComputeUtility {
 
                 diskAttachmentList << [disk:[
                     id: nonBootableDisk.id,
+                    format: 'cow',
+                    sparse: sparse,
                     'storage_domains': ['storage_domain': [[id: targetDatastoreId]]]
                 ]]
             }
@@ -819,14 +824,26 @@ class OlvmComputeUtility {
                 memory:opts.maxMemory,
                 cpu:buildCpus(opts.workloadConfig),
                 nics:[nic:buildNetworkInterfaces(interfaces)],
-                'disk_attachments':['disk_attachment': diskAttachmentList]
+                'disk_attachments':['disk_attachment': diskAttachmentList],
+                stateless: opts.stateless ?: false,
             ]
             if (biosType) {
                 postBody.bios = [type: biosType]
                 log.debug("createServer: setting vm bios type to ${biosType}")
             }
+            if (opts.hostRef) {
+                postBody.placement_policy = [
+                    hosts: [host: [[id: opts.hostRef]]],
+                    affinity: opts.hostAffinity ?: 'migratable'
+                ]
+                log.info("createServer: host placement hostRef=${opts.hostRef}, affinity=${postBody.placement_policy.affinity}")
+            }
+            log.info("createServer: stateless=${opts.stateless}, diskProvisioning=${opts.diskProvisioning}, cloneType=${opts.cloneType}")
             def postHeaders = getAuthenticatedBaseHeaders(connection)
             def postReqOptions = new HttpApiClient.RequestOptions(headers:postHeaders, body:postBody, ignoreSSL:true)
+            if (opts.cloneType == 'full') {
+                postReqOptions.queryParams = [clone: 'true']
+            }
             response = client.callJsonApi(
                 connection.apiUrl,
                 '/ovirt-engine/api/vms/',


### PR DESCRIPTION
…ptions (MORPH-8443)

- New provisioning options in Advanced Options:
  - Clone Type: linked (default) or full clone (?clone=true query param)
  - Disk Provisioning: thin/sparse (default) or preallocated; sets format:cow + sparse on all disk attachments
  - Stateless VM: checkbox that sets stateless flag on VM create; auto-corrects to thin if preallocated was selected
  - Host: dropdown filtered to hosts in the selected cluster (olvmHosts option source)
  - Host Affinity: migratable (default), user_migratable, or pinned; sets placement_policy on VM create

- All five new fields shown on the review screen (displayValueOnDetails: true)
- Three static option sources added: olvmCloneTypes, olvmDiskProvisioningTypes, olvmHostAffinityTypes