### PR TITLE
chore: ignore hero-engine local/session state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ build
 lib/
 src/main/resources/olvm-plugin.properties
 
+# heroengine.ai
+.hero/index.db
+.hero/graph.db
+.hero/events.log
+.hero/hero.local.json
+.hero/next/*.local.md
+.hero/sessions
+


### PR DESCRIPTION
## Problem
heroengine.ai state files (index/graph DBs, event logs, local session notes) were not covered by .gitignore, risking accidental commits of local/session-specific state via the repo's pre-commit hook, which auto-stages .hero/* handoff files on every commit.

## Fix
Add .gitignore entries for:
- .hero/index.db, .hero/graph.db, .hero/events.log - local index/cache state
- .hero/hero.local.json - local machine config
- .hero/next/*.local.md - per-user local handoff notes (not meant to be shared)
- .hero/sessions - local session state

## Note
While investigating this, found that the repo's pre-commit hook (.git/hooks/pre-commit) re-stages .hero/NEXT.md, .hero/QUEUE.md, .hero/SNAPSHOT.md, .hero/peer-manifest.yaml, and .hero/next/*.md on every commit. This had already leaked into two currently-open PRs (#17, #18) targeting api-1.2.x, which never had any .hero/* files tracked before. Both PRs have been amended to remove the accidental .hero/* content.
