### PR TITLE
MORPH-15720: Set removable=true on OLVM-added data disks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.1.11
+version=1.1.12
 karmanVersion=2.3.0
 morpheusApiVersion=1.2.8
 morpheusPluginGradleVersion=1.0.6

--- a/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
@@ -1118,7 +1118,8 @@ class OlvmProvisionProvider extends AbstractProvisionProvider implements VmProvi
 						name: newVolumeProps.name,
 						displayOrder: newCounter,
 						status: 'provisioned',
-						rootVolume:false
+						rootVolume:false,
+						removable:true
 					)
 					log.info("Saving Volume")
 					morpheus.async.storageVolume.create([newVolume], server).blockingGet()


### PR DESCRIPTION
## Summary
Fixes a regression where the "remove disk" action (trash-can icon) is missing from the resize/reconfigure instance disk list for OLVM's additional (non-root) disks.

## Root Cause
The Morpheus `morpheus-plugin-api` `StorageVolume` model defaults `removable` to `false` in its constructor. `OlvmProvisionProvider`'s disk add/resize flow (`addDiskToVm`/resize handling, ~line 1108) constructs new `StorageVolume` instances without ever setting `removable`, so every OLVM-added disk silently inherits `removable=false`. The UI's existing check (`volume?.removable`) correctly hides the remove icon for `removable=false` — the plugin was simply never marking its own disks as removable in the first place.

This matches the pattern already used in core provisioning for non-plugin provision types, in `AbstractComputeService.buildComputeServerVolumes()`:
```groovy
storageVolume.removable = storageVolume.rootVolume != true
```
which OLVM's plugin-based provisioning never goes through.

## Fix
Explicitly set `removable:true` when constructing new (non-root) `StorageVolume` instances in `OlvmProvisionProvider.groovy`. Version bumped to 1.1.12.

## Note on companion morpheus-ui PR #5321
A companion PR ([HPE-EMU/morpheus-ui#5321](https://github.com/HPE-EMU/morpheus-ui/pull/5321)) loosened the GSP/JS `removable` check from `volume?.removable` to `volume?.removable != false`, intended to treat a `null`/unset value as removable. However `storage_volume.removable` is a `NOT NULL` database column, so a persisted volume's `removable` can only ever be `true` or `false` — never `null`. That change was therefore a no-op for any real disk and did not address the regression. PR #5321 has been closed; this plugin-side fix addresses the actual root cause.

## Testing
- Verified locally: before the fix, a disk added via OLVM resize has `removable=false` in `storage_volume` and the trash-can icon is correctly hidden per the (unmodified) UI check — reproducing the reported bug.
- After deploying this fix and testing an OLVM disk add, `removable` is now explicitly `true`, and the trash-can icon appears as expected.
- `./gradlew compileGroovy` passes.

JIRA: https://hpe.atlassian.net/browse/MORPH-15720