### PR TITLE
MORPH-15724: Fix OLVM backup restore hanging indefinitely on VM start

### DIFF
--- a/src/main/groovy/com/morpheus/olvm/util/OlvmComputeUtility.groovy
+++ b/src/main/groovy/com/morpheus/olvm/util/OlvmComputeUtility.groovy
@@ -1078,7 +1078,7 @@ class OlvmComputeUtility {
             if (response.success) {
                 def reqOptions = new HttpApiClient.RequestOptions(headers:headers, ignoreSSL:true)
                 // wait for the VM to be down
-                rtn = waitForSomeStuffToHappen([label: "Start vm ${opts.server?.name}", timeout: (5l * 60l)]) {
+                rtn = waitForSomeStuffToHappen([label: "Stop vm ${opts.server?.name}", timeout: (5l * 60l)]) {
                     response = client.callJsonApi(
                         connection.apiUrl,
                         "/ovirt-engine/api/vms/${vmExternalId}".toString(),

--- a/src/main/groovy/com/morpheus/olvm/util/OlvmComputeUtility.groovy
+++ b/src/main/groovy/com/morpheus/olvm/util/OlvmComputeUtility.groovy
@@ -964,7 +964,7 @@ class OlvmComputeUtility {
 
             if (response.success) {
                 def reqOptions = new HttpApiClient.RequestOptions(headers:headers, ignoreSSL:true)
-                rtn = waitForSomeStuffToHappen([label: "Start vm ${opts.server?.name}", timeout: (5l * 60l * 1000l)]) {
+                rtn = waitForSomeStuffToHappen([label: "Start vm ${opts.server?.name}", timeout: (5l * 60l)]) {
                     response = client.callJsonApi(
                         connection.apiUrl,
                         "/ovirt-engine/api/vms/${vmExternalId}".toString(),
@@ -1011,27 +1011,36 @@ class OlvmComputeUtility {
             if (response.success) {
                 def vm = response.data
                 if (vm.status != 'up') {
-                    // if our vm status is not up, send the start command
                     def actionBody = [async:true]
                     def postHeaders = getAuthenticatedBaseHeaders(connection)
                     postHeaders['Content-Type'] = 'application/json'
                     def postReqOptions = new HttpApiClient.RequestOptions(headers:headers, body:actionBody, ignoreSSL:true)
-                    response = client.callJsonApi(
-                        connection.apiUrl,
-                        "/ovirt-engine/api/vms/${vmExternalId}/start".toString(),
-                        postReqOptions,
-                        'POST'
-                    )
 
-                    // wait for the VM to be up
-                    rtn = waitForSomeStuffToHappen([label: "Start vm ${opts.server?.name}", timeout: (5l * 60l * 1000l)]) {
+                    // the start command can fail with 409 while a related operation (e.g. a
+                    // just-completed restore/disk-attach) is still finishing server-side, so
+                    // retry the start command itself, not just poll status, until it is accepted
+                    // or the VM comes up on its own.
+                    rtn = waitForSomeStuffToHappen([label: "Start vm ${opts.server?.name}", timeout: (5l * 60l)]) {
                         response = client.callJsonApi(
                             connection.apiUrl,
                             "/ovirt-engine/api/vms/${vmExternalId}".toString(),
                             reqOptions,
                             'GET'
                         )
-                        return response.data.status == 'up'
+                        if (response.data?.status == 'up') {
+                            return true
+                        }
+
+                        def startResponse = client.callJsonApi(
+                            connection.apiUrl,
+                            "/ovirt-engine/api/vms/${vmExternalId}/start".toString(),
+                            postReqOptions,
+                            'POST'
+                        )
+                        if (!startResponse.success && startResponse.errorCode != '409') {
+                            log.warn("startVm: unexpected error starting vm ${vmExternalId}: ${extractErrorMessage(startResponse.data) ?: startResponse.msg}")
+                        }
+                        return false
                     }
                 } else {
                     // if its already started then just ignore
@@ -1069,7 +1078,7 @@ class OlvmComputeUtility {
             if (response.success) {
                 def reqOptions = new HttpApiClient.RequestOptions(headers:headers, ignoreSSL:true)
                 // wait for the VM to be down
-                rtn = waitForSomeStuffToHappen([label: "Start vm ${opts.server?.name}", timeout: (5l * 60l * 1000l)]) {
+                rtn = waitForSomeStuffToHappen([label: "Start vm ${opts.server?.name}", timeout: (5l * 60l)]) {
                     response = client.callJsonApi(
                         connection.apiUrl,
                         "/ovirt-engine/api/vms/${vmExternalId}".toString(),
@@ -1938,15 +1947,18 @@ class OlvmComputeUtility {
     static ServiceResponse waitForSomeStuffToHappen(Map opts, Closure clos) {
         def rtn = ServiceResponse.prepare()
         def timeout = opts.timeout ?: DEFAULT_WAIT_TIMEOUT
-        def expired = false
         def startTime = System.currentTimeMillis()
+        def conditionMet = false
 
         while (System.currentTimeMillis() - startTime < (timeout * 1000l)) {
-            if (clos.call(opts))
+            if (clos.call(opts)) {
+                conditionMet = true
                 break
+            }
             sleep(3000l)
         }
-        if (expired) {
+        if (!conditionMet) {
+            rtn.success = false
             rtn.error = "Operation timed out: ${opts.label ?: 'operation not labeled'}"
         }
         else {


### PR DESCRIPTION
## Summary
Fixes OLVM backup restore to the same instance hanging indefinitely instead of completing.

## Root Cause
`OlvmSnapshotRestoreProvider.restoreBackup()` calls `OlvmComputeUtility.startVm()` to restart the VM after a snapshot restore completes. oVirt can respond to the `/start` command with a `409` ("Cannot run VM. Related operation is currently in progress") while the just-finished restore/disk-attach operation is still settling server-side. `startVm()` ignored that failure and fell straight into a polling loop waiting for VM status `up`, which never happens since the start command was never actually accepted.

Two additional bugs turned this into an effectively **infinite** hang rather than a bounded failure:
- `waitForSomeStuffToHappen()` declared an `expired` flag but never set it on timeout, so it silently returned `success=true` after timing out instead of surfacing a timeout error.
- `startVm`/`startVmWithCloudInit`/`stopVm` passed `timeout:(5l * 60l * 1000l)` intending "5 minutes", but `waitForSomeStuffToHappen` treats `timeout` as **seconds** (multiplying by 1000 internally for millis) — so the actual effective timeout was ~300,000 seconds (~83 hours).

## Fix
- `startVm()` now retries the `/start` POST itself on each poll iteration (instead of assuming a single POST succeeded), so it recovers automatically once the VM's in-progress operation clears.
- `waitForSomeStuffToHappen()` now correctly reports failure on timeout.
- Corrected the timeout units at all 3 call sites (`startVm`, `startVmWithCloudInit`, `stopVm`) so they actually mean 5 minutes.

## Verification
Reproduced the indefinite hang live on unpatched `api-1.2.x` via provision -> 2 backups -> restore backup #1 to same instance. Confirmed restore process stuck at 0%/"In progress" indefinitely (past 30+ min), with logs showing repeated 409s on `/start` and no further activity.

Applied this fix and re-ran the same scenario: restore completed in ~40 seconds, instance came up `running`, logs showed the `/start` retry succeeding once the underlying oVirt operation cleared.

## Related
- MORPH-15724: https://hpe.atlassian.net/browse/MORPH-15724
- Note: `HPE-EMU/morpheus-ui` PR #5320 (`sanitizePluginOpts()`) was initially proposed as the fix for this ticket but does not address this root cause -- no plugin-boundary marshalling failure was observed during live reproduction. That PR is still a worthwhile independent hygiene improvement (stripping non-serializable domain objects from opts crossing the plugin RPC boundary) but is a separate change.
