### PR TITLE
MORPH-15890: don't clobber dhcpServer when no host attachment data is found

### DIFF
--- a/src/main/groovy/com/morpheus/olvm/sync/NetworkSync.groovy
+++ b/src/main/groovy/com/morpheus/olvm/sync/NetworkSync.groovy
@@ -132,7 +132,7 @@ class NetworkSync {
             def save = false
             def description = masterItem.description
             def cidr = networkIpAssignmentToCidr(masterItem.ipAssignment)
-            def dhcpServer = masterItem.ipAssignment ? (masterItem.ipAssignment?.assignment_method == 'dhcp') : null
+            def dhcpServer = definitiveDhcpServer(masterItem.ipAssignment)
 
             if (existingItem.name != masterItem.name) {
                 existingItem.name = masterItem.name
@@ -153,9 +153,11 @@ class NetworkSync {
                 existingItem.cidr = cidr
                 save = true
             }
-            // only trust dhcpServer when we actually found host network attachment data;
-            // absence of attachment data (the common case for VM-only networks) is not
-            // evidence of "not DHCP" and must never clobber an already-known true value
+            // only trust dhcpServer when the host network attachment reports a definitive
+            // assignment_method ('dhcp' or 'static'); absent attachment data or 'none' (the
+            // normal, expected value for VM-only bridged networks, where the host itself has
+            // no IP on the interface) says nothing about how guest VMs are addressed and must
+            // never clobber an already-known value
             if (dhcpServer != null && existingItem.dhcpServer != dhcpServer) {
                 existingItem.dhcpServer = dhcpServer
                 save = true
@@ -165,6 +167,17 @@ class NetworkSync {
         }
         if (updates)
             morpheusContext.async.network.save(updates).blockingGet()
+    }
+
+    // returns whether the host network attachment reports a definitive DHCP/static assignment_method,
+    // or null when the signal is absent or 'none' (the normal value for VM-only bridged networks,
+    // where the host has no IP on the interface); null means "no usable signal", not "not DHCP"
+    protected Boolean definitiveDhcpServer(ipAssignment) {
+        def assignmentMethod = ipAssignment?.assignment_method
+        if (assignmentMethod == 'dhcp' || assignmentMethod == 'static') {
+            return assignmentMethod == 'dhcp'
+        }
+        return null
     }
 
     // computes a CIDR string from an oVirt ip_address_assignment (host network_attachment), if available

--- a/src/main/groovy/com/morpheus/olvm/sync/NetworkSync.groovy
+++ b/src/main/groovy/com/morpheus/olvm/sync/NetworkSync.groovy
@@ -132,7 +132,7 @@ class NetworkSync {
             def save = false
             def description = masterItem.description
             def cidr = networkIpAssignmentToCidr(masterItem.ipAssignment)
-            def dhcpServer = masterItem.ipAssignment?.assignment_method == 'dhcp'
+            def dhcpServer = masterItem.ipAssignment ? (masterItem.ipAssignment?.assignment_method == 'dhcp') : null
 
             if (existingItem.name != masterItem.name) {
                 existingItem.name = masterItem.name
@@ -153,7 +153,10 @@ class NetworkSync {
                 existingItem.cidr = cidr
                 save = true
             }
-            if (existingItem.dhcpServer != dhcpServer) {
+            // only trust dhcpServer when we actually found host network attachment data;
+            // absence of attachment data (the common case for VM-only networks) is not
+            // evidence of "not DHCP" and must never clobber an already-known true value
+            if (dhcpServer != null && existingItem.dhcpServer != dhcpServer) {
                 existingItem.dhcpServer = dhcpServer
                 save = true
             }

--- a/src/test/groovy/com/morpheus/olvm/sync/NetworkSyncSpec.groovy
+++ b/src/test/groovy/com/morpheus/olvm/sync/NetworkSyncSpec.groovy
@@ -122,6 +122,35 @@ class NetworkSyncSpec extends Specification {
 		existingItem.dhcpServer == true
 	}
 
+	def "updateMatchedNetworks does not clobber a known dhcpServer=true when host attachment reports assignment_method 'none'"() {
+		// MORPH-15890 (live repro): every OLVM host reports assignment_method 'none' for VM-only
+		// bridged networks like VLAN2063, because the host itself has no IP on that interface.
+		// This is real, present ipAssignment data - not absence of data - but it says nothing
+		// about whether guest VMs on the network are addressed via DHCP, and must not clobber
+		// an already-known true value.
+		given:
+		def existingItem = new NetworkModel(cidr: '10.32.148.0/22', dhcpServer: true)
+		def masterItem = [
+			name: 'VLAN2063',
+			description: 'VLAN2063',
+			ipAssignment: [assignment_method: 'none', ip: [version: 'v4']]
+		]
+		def updateItem = new SyncList.UpdateItem<NetworkModel, Map>(existingItem, masterItem, false)
+		def morpheusContext = Mock(MorpheusContext)
+		def asyncContext = Mock(MorpheusAsyncServices)
+		def networkContext = Mock(MorpheusNetworkService)
+		morpheusContext.async >> asyncContext
+		asyncContext.network >> networkContext
+		networkContext.save(_) >> Single.just(true)
+		networkSync.@morpheusContext = morpheusContext
+
+		when:
+		networkSync.updateMatchedNetworks([updateItem])
+
+		then:
+		existingItem.dhcpServer == true
+	}
+
 	def "updateMatchedNetworks updates dhcpServer when host attachment data is found"() {
 		given:
 		def existingItem = new NetworkModel(cidr: '10.32.148.0/22', dhcpServer: false)

--- a/src/test/groovy/com/morpheus/olvm/sync/NetworkSyncSpec.groovy
+++ b/src/test/groovy/com/morpheus/olvm/sync/NetworkSyncSpec.groovy
@@ -93,4 +93,56 @@ class NetworkSyncSpec extends Specification {
 		then:
 		existingItem.cidr == '10.10.10.0/24'
 	}
+
+	def "updateMatchedNetworks does not clobber a known dhcpServer=true when no host attachment data is found"() {
+		// MORPH-15890: VM-only networks (e.g. VLAN2063) are consumed via vnic profiles and are
+		// rarely attached directly to a host NIC, so masterItem.ipAssignment is null on most
+		// syncs even though the network really is DHCP-based. Missing attachment data must not
+		// be treated as proof the network is static.
+		given:
+		def existingItem = new NetworkModel(cidr: '10.32.148.0/22', dhcpServer: true)
+		def masterItem = [
+			name: 'VLAN2063',
+			description: 'VLAN2063',
+			ipAssignment: null
+		]
+		def updateItem = new SyncList.UpdateItem<NetworkModel, Map>(existingItem, masterItem, false)
+		def morpheusContext = Mock(MorpheusContext)
+		def asyncContext = Mock(MorpheusAsyncServices)
+		def networkContext = Mock(MorpheusNetworkService)
+		morpheusContext.async >> asyncContext
+		asyncContext.network >> networkContext
+		networkContext.save(_) >> Single.just(true)
+		networkSync.@morpheusContext = morpheusContext
+
+		when:
+		networkSync.updateMatchedNetworks([updateItem])
+
+		then:
+		existingItem.dhcpServer == true
+	}
+
+	def "updateMatchedNetworks updates dhcpServer when host attachment data is found"() {
+		given:
+		def existingItem = new NetworkModel(cidr: '10.32.148.0/22', dhcpServer: false)
+		def masterItem = [
+			name: 'VLAN2063',
+			description: 'VLAN2063',
+			ipAssignment: [assignment_method: 'dhcp', ip: [address: '10.32.148.1', netmask: '255.255.252.0']]
+		]
+		def updateItem = new SyncList.UpdateItem<NetworkModel, Map>(existingItem, masterItem, false)
+		def morpheusContext = Mock(MorpheusContext)
+		def asyncContext = Mock(MorpheusAsyncServices)
+		def networkContext = Mock(MorpheusNetworkService)
+		morpheusContext.async >> asyncContext
+		asyncContext.network >> networkContext
+		networkContext.save(_) >> Single.just(true)
+		networkSync.@morpheusContext = morpheusContext
+
+		when:
+		networkSync.updateMatchedNetworks([updateItem])
+
+		then:
+		existingItem.dhcpServer == true
+	}
 }


### PR DESCRIPTION
## Summary
Fixes MORPH-15890 — OLVM Reconfigure Instance Modal shows an editable static IP instead of the DHCP label for DHCP-configured networks.

## Root cause
`NetworkSync.updateMatchedNetworks()` (added in MORPH-15725, #22) derives `dhcpServer` from host-level `network_attachments` data. VM-only networks (consumed via vnic profiles, e.g. VLAN2063) are almost never attached directly to a host NIC, so `masterItem.ipAssignment` is `null` on most sync passes even when the network genuinely uses DHCP.

Because the code unconditionally did:
```groovy
if (existingItem.dhcpServer != dhcpServer) {
    existingItem.dhcpServer = dhcpServer
    save = true
}
```
missing attachment data (computed `dhcpServer = false`) was treated as proof the network is static, silently flipping a previously-correct `dhcpServer = true` back to `false` on the very next sync — reintroducing the exact clobbering behavior MORPH-15725 was meant to fix, one layer up (in the plugin instead of morpheus-core).

## Fix
Only update `dhcpServer` when host attachment data actually confirms a value (`masterItem.ipAssignment` present). When absent, preserve the existing flag — mirroring the existing "don't clobber a real cidr" guard already in the same method.

## Testing
Added two regression tests to `NetworkSyncSpec`:
- `dhcpServer=true` is preserved when no host attachment data is found
- `dhcpServer` still updates correctly when attachment data is found

All 8 tests in `NetworkSyncSpec` pass locally (JDK 17).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
