### PR TITLE
MORPH-16077: Implement restartWorkload to actually stop/start the VM

### DIFF
--- a/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
+++ b/src/main/groovy/com/morpheus/olvm/OlvmProvisionProvider.groovy
@@ -1331,8 +1331,12 @@ class OlvmProvisionProvider extends AbstractProvisionProvider implements VmProvi
 	 */
 	@Override
 	ServiceResponse restartWorkload(Workload workload) {
-		// Generally a call to stopWorkLoad() and then startWorkload()
-		return ServiceResponse.success()
+		log.debug "restartWorkload: ${workload}"
+		ServiceResponse stopResult = stopWorkload(workload)
+		if (stopResult.success) {
+			return startWorkload(workload)
+		}
+		return stopResult
 	}
 
 	/**

--- a/src/test/groovy/com/morpheus/olvm/OlvmProvisionProviderRestartWorkloadSpec.groovy
+++ b/src/test/groovy/com/morpheus/olvm/OlvmProvisionProviderRestartWorkloadSpec.groovy
@@ -1,0 +1,44 @@
+package com.morpheus.olvm
+
+import com.morpheusdata.model.Workload
+import com.morpheusdata.response.ServiceResponse
+import spock.lang.Specification
+
+/**
+ * MORPH-16077: restartWorkload previously always returned ServiceResponse.success() without ever
+ * issuing stop/start calls against OLVM, so the "Restart" instance action reported success but never
+ * actually power-cycled the VM. It must delegate to stopWorkload()/startWorkload() (mirroring the
+ * pattern used by the other provision providers) so a real restart is attempted, and must propagate
+ * failure if the stop step doesn't succeed rather than silently continuing to start.
+ */
+class OlvmProvisionProviderRestartWorkloadSpec extends Specification {
+
+	OlvmProvisionProvider provider = Spy(OlvmProvisionProvider, constructorArgs: [null, null])
+
+	def "restartWorkload stops then starts the workload when the stop succeeds"() {
+		given:
+		Workload workload = new Workload()
+		1 * provider.stopWorkload(workload) >> ServiceResponse.success()
+		1 * provider.startWorkload(workload) >> ServiceResponse.success()
+
+		when:
+		ServiceResponse result = provider.restartWorkload(workload)
+
+		then:
+		result.success == true
+	}
+
+	def "restartWorkload does not attempt to start when the stop fails"() {
+		given:
+		Workload workload = new Workload()
+		1 * provider.stopWorkload(workload) >> ServiceResponse.error('Failed to stop vm')
+		0 * provider.startWorkload(_)
+
+		when:
+		ServiceResponse result = provider.restartWorkload(workload)
+
+		then:
+		result.success == false
+		result.errors?.error == 'Failed to stop vm'
+	}
+}


### PR DESCRIPTION
## Summary
Fixes the second half of [MORPH-16077](https://hpe.atlassian.net/browse/MORPH-16077): "OLVM Cloud – Instance Restart Fails Server-Side, VM Never Reboots". This companion fix lives here in the OLVM plugin; see HPE-EMU/morpheus-ui#5420 for the paired server-side crash fix.

## Root cause
`restartWorkload()` was a no-op stub:
```groovy
@Override
ServiceResponse restartWorkload(Workload workload) {
    // Generally a call to stopWorkLoad() and then startWorkload()
    return ServiceResponse.success()
}
```
It always reported success without ever calling the OLVM API to actually restart the VM. `stopWorkload`/`startWorkload` (which delegate to `stopServer`/`startServer`) already make real OLVM API calls correctly - `restartWorkload` just never used them.

This matches the reported symptoms: `who -b` showed the same boot time before and after the restart action, and an active SSH session stayed connected through the "restart".

## Fix
Delegate to `stopWorkload()`/`startWorkload()`, propagating failure if the stop step does not succeed rather than silently continuing to start - matching the pattern used by other provision providers (Nutanix, OpenStack, DigitalOcean) and by `stopServer`/`startServer` in this same class.

## Testing
- `./gradlew compileGroovy` - compiles cleanly (JDK 17)
- Added `OlvmProvisionProviderRestartWorkloadSpec` covering the stop-succeeds and stop-fails paths
- `./gradlew test --tests "com.morpheus.olvm.OlvmProvisionProviderRestartWorkloadSpec"` - 2/2 passing
- Verified live against a local OLVM cloud instance: before the fix, `who -b` was unchanged and the SSH session stayed alive through a restart; after deploying the fix, the SSH session was dropped (Connection reset by peer) and `who -b` reported a new boot time.
